### PR TITLE
Use `dns_name` instead of `name` for resource attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,38 +48,38 @@ use the API.
 The type of record can be one of the following: A, CNAME, ALIAS, MX,
 SPF, URL, TXT, NS, SRV, NAPTR, PTR, AAA, SSHFP, or HFINO.
 
-    | Parameter  | Description                | Default |
-    |------------|----------------------------|---------|
-    | *domain*   | Domain to manage           |         |
-    | *name*     | _Name_: Name of the record |         |
-    | *type*     | Type of DNS record         |         |
-    | *content*  | String content of record   |         |
-    | *ttl*      | Time to live.              | 3600    |
-    | *priority* | Priorty of update          |         |
-    | *username* | DNSimple username          |         |
-    | *password* | DNSimple password          |         |
-    | *test*     | Unused at this time        | false   |
+    | Parameter     | Description                | Default |
+    |---------------|----------------------------|---------|
+    | *domain*      | Domain to manage           |         |
+    | *record_name* | _Name_: Name of the record |         |
+    | *type*        | Type of DNS record         |         |
+    | *content*     | String content of record   |         |
+    | *ttl*         | Time to live.              | 3600    |
+    | *priority*    | Priority of update         |         |
+    | *username*    | DNSimple username          |         |
+    | *password*    | DNSimple password          |         |
+    | *test*        | Unused at this time        | false   |
 
 ### Examples
 
     dnsimple_record "create an A record" do
-      name     "test"
-      content  "16.8.4.2"
-      type     "A"
-      domain   node[:dnsimple][:domain]
-      username node[:dnsimple][:username]
-      password node[:dnsimple][:password]
-      action   :create
+      record_name "test"
+      content     "16.8.4.2"
+      type        "A"
+      domain      node[:dnsimple][:domain]
+      username    node[:dnsimple][:username]
+      password    node[:dnsimple][:password]
+      action      :create
     end
 
     dnsimple_record "create a CNAME record for a Google Apps site calendar" do
-      name     "calendar"
-      content  "ghs.google.com"
-      type     "CNAME"
-      domain   node[:dnsimple][:domain]
-      username node[:dnsimple][:username]
-      password node[:dnsimple][:password]
-      action   :create
+      record_name "calendar"
+      content     "ghs.google.com"
+      type        "CNAME"
+      domain      node[:dnsimple][:domain]
+      username    node[:dnsimple][:username]
+      password    node[:dnsimple][:password]
+      action      :create
     end
 
 ## Usage

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -23,8 +23,8 @@ def whyrun_supported?
 end
 
 def load_current_resource
-  @current_resource = Chef::Resource::DnsimpleRecord.new(@new_resource.name)
-  @current_resource.name(@new_resource.name)
+  @current_resource = Chef::Resource::DnsimpleRecord.new(@new_resource.record_name)
+  @current_resource.record_name(@new_resource.record_name)
   @current_resource.domain(@new_resource.domain)
 
   @current_resource.exists = check_for_record
@@ -52,7 +52,7 @@ end
 
 def check_for_record
   all_records_in_zone do |r|
-    if ((r.name == new_resource.name) && (r.type == new_resource.type))
+    if ((r.name == new_resource.record_name) && (r.type == new_resource.type))
       if ((r.value == new_resource.content) && (r.ttl == new_resource.ttl))
         return :same
       else
@@ -64,30 +64,30 @@ def check_for_record
 end
 
 def create_record
-  Chef::Log.debug "Attempting to create record type #{new_resource.type} for #{new_resource.name} as #{new_resource.content} with type #{new_resource.type}"
+  Chef::Log.debug "Attempting to create record type #{new_resource.type} for #{new_resource.record_name} as #{new_resource.content} with type #{new_resource.type}"
   zone = dnsimple.zones.get( new_resource.domain )
-  record = zone.records.create( :name  => new_resource.name,
+  record = zone.records.create( :name  => new_resource.record_name,
                                :value => new_resource.content,
                                :type  => new_resource.type,
                                :ttl   => new_resource.ttl )
   new_resource.updated_by_last_action(true)
-  Chef::Log.info "DNSimple: created #{new_resource.type} record for #{new_resource.name}.#{new_resource.domain}"
+  Chef::Log.info "DNSimple: created #{new_resource.type} record for #{new_resource.record_name}.#{new_resource.domain}"
 rescue Excon::Errors::UnprocessableEntity
-  Chef::Log.debug "DNSimple: #{new_resource.name}.#{new_resource.domain} already exists, moving on"
+  Chef::Log.debug "DNSimple: #{new_resource.record_name}.#{new_resource.domain} already exists, moving on"
 end
 
 def delete_record
   if [:same, :different].include?(@current_resource.exists)
     all_records_in_zone do |r|
-      if (( r.name == new_resource.name ) && ( r.type == new_resource.type ))
+      if (( r.name == new_resource.record_name ) && ( r.type == new_resource.type ))
         r.destroy
         new_resource.updated_by_last_action(true)
         Chef::Log.info "DNSimple: destroyed #{new_resource.type} record " +
-          "for #{new_resource.name}.#{new_resource.domain}"
+          "for #{new_resource.record_name}.#{new_resource.domain}"
       end
     end
   else
-    Chef::Log.info "DNSimple: no record found #{new_resource.name}.#{new_resource.domain}" +
+    Chef::Log.info "DNSimple: no record found #{new_resource.record_name}.#{new_resource.domain}" +
       " with type #{new_resource.type}"
   end
 end

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -20,13 +20,13 @@ actions :create, :destroy
 
 default_action :create
 
-attribute :domain,   :kind_of => String
-attribute :name,     :kind_of => String
-attribute :type,     :kind_of => String, :equal_to => ["A", "CNAME", "ALIAS", "MX", "SPF", "URL", "TXT", "NS", "SRV", "NAPTR", "PTR", "AAA", "SSHFP", "HFINO"]
-attribute :content,  :kind_of => String
-attribute :ttl,      :kind_of => Integer, :default => 3600
-attribute :priority, :kind_of => Integer
-attribute :username, :kind_of => String
-attribute :password, :kind_of => String
+attribute :record_name, :kind_of => String, :name_attribute => true
+attribute :domain,      :kind_of => String
+attribute :type,        :kind_of => String, :equal_to => ["A", "CNAME", "ALIAS", "MX", "SPF", "URL", "TXT", "NS", "SRV", "NAPTR", "PTR", "AAA", "SSHFP", "HFINO"]
+attribute :content,     :kind_of => String
+attribute :ttl,         :kind_of => Integer, :default => 3600
+attribute :priority,    :kind_of => Integer
+attribute :username,    :kind_of => String
+attribute :password,    :kind_of => String
 
 attr_accessor :exists

--- a/spec/record_create_existing_record_same_type_and_content_spec.rb
+++ b/spec/record_create_existing_record_same_type_and_content_spec.rb
@@ -8,7 +8,8 @@ describe 'dnsimple_test::create_record_existing_record_same_type_and_content' do
     it 'does not perform any operation' do
       create_record_to_update
 
-      dnsimple_resource = chef_run.find_resource('dnsimple_record', 'existing')
+      dnsimple_resource = chef_run
+        .find_resource('dnsimple_record', 'custom record name')
       expect(dnsimple_resource.updated_by_last_action?).to be_false
       expect(Fog::DNS::DNSimple::Record).not_to receive(:destroy)
       record = dnsimple_zone.records.detect { |r| r.name == 'existing' }

--- a/spec/record_create_existing_record_same_type_spec.rb
+++ b/spec/record_create_existing_record_same_type_spec.rb
@@ -9,7 +9,8 @@ describe 'dnsimple_test::create_record_existing_record_same_type' do
       create_record_to_update
       chef_run
 
-      dnsimple_resource = chef_run.find_resource('dnsimple_record', 'existing')
+      dnsimple_resource = chef_run
+        .find_resource('dnsimple_record', 'custom record name')
       expect(dnsimple_resource.updated_by_last_action?).to be_true
 
       record = dnsimple_zone.records.detect { |r| r.name == 'existing' }

--- a/test/fixtures/cookbooks/dnsimple_test/recipes/create_record_existing_record_same_type.rb
+++ b/test/fixtures/cookbooks/dnsimple_test/recipes/create_record_existing_record_same_type.rb
@@ -1,4 +1,5 @@
-dnsimple_record 'existing' do
+dnsimple_record 'custom record name' do
+  record_name 'existing'
   type 'A'
   content '1.1.1.1'
   domain 'example.com'

--- a/test/fixtures/cookbooks/dnsimple_test/recipes/create_record_existing_record_same_type_and_content.rb
+++ b/test/fixtures/cookbooks/dnsimple_test/recipes/create_record_existing_record_same_type_and_content.rb
@@ -1,4 +1,5 @@
-dnsimple_record 'existing' do
+dnsimple_record 'custom record name' do
+  record_name 'existing'
   type 'A'
   content '2.2.2.2'
   domain 'example.com'


### PR DESCRIPTION
The `name` resource attribute overrides the original name given to the resource. There is a special `name_attribute` which should be used for this instead (and is used in this PR).

See: https://github.com/sethvargo/chefspec/issues/356#issuecomment-36004241