### PR TITLE
Fix ChefSpec Deprecation Warning

### DIFF
--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,7 +1,7 @@
 require_relative 'spec_helper'
 
 describe 'dnsimple::default' do
-  let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new.converge(described_recipe) }
 
   it 'installs libxml2-dev and libxslt1-dev packages' do
     expect(chef_run).to install_package 'libxml2-dev'

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -1,6 +1,6 @@
 shared_context 'dnsimple' do
   let(:chef_run) do
-    runner = ChefSpec::Runner.new(:step_into => ['dnsimple_record'])
+    runner = ChefSpec::ServerRunner.new(:step_into => ['dnsimple_record'])
     runner.converge(described_recipe)
   end
   before(:all) do


### PR DESCRIPTION
ChefSpec changed from ChefSpec::Runner to either
ChefSpec::ServerRunner or ChefSpec::SoloRunner.

This updates the tests to use ChefSpec::ServerRunner

Fixes GH Issue #25